### PR TITLE
haxe specific implementation discussion PR (don't merge!)

### DIFF
--- a/src/luasimdjson.cpp
+++ b/src/luasimdjson.cpp
@@ -36,17 +36,23 @@ void convert_element_to_table(lua_State *L, dom::element element) {
   switch (element.type()) {
     case dom::element_type::ARRAY:
       {
-          int count = 1;
+          int count = 0;
           lua_newtable(L);
+          lua_getglobal(L, "_hx_array_mt");
+          lua_setmetatable(L, 2);
           for (dom::element child : dom::array(element)) {
             lua_pushinteger(L, count);
             convert_element_to_table(L, child);
-            lua_settable(L, -3);
+
+            lua_rawset(L, -3);
             count = count + 1;
           }
+          lua_pushstring(L, "length");
+          lua_pushnumber(L, count);
+          lua_rawset(L, -3);
           break;
       }
-    
+
     case dom::element_type::OBJECT:
       lua_newtable(L);
       for (dom::key_value_pair field : dom::object(element)) {
@@ -58,7 +64,7 @@ void convert_element_to_table(lua_State *L, dom::element element) {
         lua_settable(L, -3);
       }
       break;
-    
+
     case dom::element_type::INT64:
       lua_pushinteger(L, int64_t(element));
       break;
@@ -66,7 +72,7 @@ void convert_element_to_table(lua_State *L, dom::element element) {
     case dom::element_type::UINT64:
       lua_pushinteger(L, int64_t(element));
       break;
-    
+
     case dom::element_type::DOUBLE:
       lua_pushnumber(L, double(element));
       break;
@@ -81,7 +87,7 @@ void convert_element_to_table(lua_State *L, dom::element element) {
     case dom::element_type::BOOL:
       lua_pushboolean(L, bool(element));
       break;
-    
+
     case dom::element_type::NULL_VALUE:
       lua_pushlightuserdata(L, NULL);
       break;
@@ -192,7 +198,7 @@ static int ParsedObject_open_file(lua_State *L)
 
 static int ParsedObject_at(lua_State *L) {
     dom::document* document = (*reinterpret_cast<ParsedObject**>(luaL_checkudata(L, 1, LUA_MYOBJECT)))->get();
-    const char *pointer = luaL_checkstring(L, 2);    
+    const char *pointer = luaL_checkstring(L, 2);
 
     dom::element returned_element;
     simdjson::error_code error;
@@ -240,6 +246,6 @@ int luaopen_simdjson (lua_State *L) {
     lua_setfield(L, -2, "_NAME");
     lua_pushliteral(L, LUA_SIMDJSON_VERSION);
     lua_setfield(L, -2, "_VERSION");
-    
+
     return 1;
 }


### PR DESCRIPTION
I was intrigued by the simdjson library, and happy to see that you wrote a Lua wrapper for it.

I'm targetting lua using a transpiler ([Haxe](https://haxe.org/)).  Haxe has first class arrays, and they're different than Lua tables in these ways:

- They're indexed from zero
- They have a specific metatable (that keeps explicit track of length)
- They have a `length` field, that is updated through metatable methods on the table.

 I'm wondering how best I could adapt your library here for that behavior.  I've made some small alterations here that work for Haxe, but will naturally not work for "vanilla" Lua.

I think the two approaches I see that could work are:

1. Add some additional arguments to `convert_element_to_table` :  This is easy for specifying a starting index, and the metatable, but would need an additional operation to set the length.
2. Add a haxe-specific method (e.g. `parseHaxe`) : This would be way easier to specify, but perhaps you don't want to maintain that method.
3. Add a special "customization" object to `convert_element_to_table` that manages all the configuration via callbacks. (E.g. sax-like parsing options like "start_array", "end_array", etc.)

In any event, thanks for the library.  I know it's a work in progress, but it's covering some initial goals I had in mind.

