### PR TITLE
add CI configuration for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on: push
+
+jobs:
+  lua:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lua: lua=5.1
+          - lua: lua=5.2
+          - lua: lua=5.3
+          - lua: lua=5.4
+          - lua: luajit=2.0
+          - lua: luajit=2.1
+    runs-on: ubuntu-22.04
+    steps:
+      # Checks-out the repository under $GITHUB_WORKSPACE.
+      - uses: actions/checkout@v3
+      - name: Install Lua (${{ matrix.lua }})
+        run: |
+          pip install hererocks
+          hererocks lua_install -r^ --${{ matrix.lua }}
+          export PATH=$PATH:$PWD/lua_install/bin
+          luarocks install lua-cjson2
+      - name: Build lua-simdjson
+        run: |
+          export PATH=$PATH:$PWD/lua_install/bin
+          luarocks make
+      - name: Run tests
+        run: |
+          export PATH=$PATH:$PWD/lua_install/bin
+          luarocks install busted
+          busted --verbose


### PR DESCRIPTION
@FourierTransformer: Since Travis CI does not seem to do any builds for this repository anymore (see https://app.travis-ci.com/FourierTransformer/lua-simdjson), I suggest to move to GitHub Actions as a replacement.

This pull request introduces a GitHub Actions configuration that performs the equivalent of the Linux builds that Travis CI did, but with a newer version of GCC / g++ (the one that is shipping with the Ubuntu 22.04 image for GitHub Actions).

