### PR TITLE
[make] Remove broken -L flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,12 @@
 SRC = src/luasimdjson.cpp src/simdjson.cpp
 INCLUDE = -I$(LUA_INCDIR)
-LIBS_PATH = -L$(LUA_LIBDIR)
 LIBS = -lpthread
 FLAGS = -std=c++11 -Wall $(LIBFLAG) $(CFLAGS)
 
 all: simdjson.so
 
 simdjson.so:
-	$(CXX) $(SRC) $(FLAGS) $(INCLUDE) $(LIBS_PATH) $(LIBS) -o $@
+	$(CXX) $(SRC) $(FLAGS) $(INCLUDE) $(LIBS) -o $@
 
 clean:
 	rm *.so

--- a/lua-simdjson-0.0.2-1.rockspec
+++ b/lua-simdjson-0.0.2-1.rockspec
@@ -20,7 +20,6 @@ build = {
    build_variables = {
       CFLAGS="$(CFLAGS)",
       LIBFLAG="$(LIBFLAG)",
-      LUA_LIBDIR="$(LUA_LIBDIR)",
       LUA_BINDIR="$(LUA_BINDIR)",
       LUA_INCDIR="$(LUA_INCDIR)",
       LUA="$(LUA)",


### PR DESCRIPTION
LUA_LIBDIR is not available on most platforms, so this gives an empty variable which means -L swallows up the -lpthread flag.

Closes #78.

(See #82 for what windows needs)