### PR TITLE
ci: update actions/checkout in GitHub Actions workflows to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE.
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Lua (${{ matrix.lua }})
         run: |
           pip install hererocks
@@ -44,7 +44,7 @@ jobs:
     runs-on: windows-2022
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE.
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Lua (${{ matrix.lua }})
         run: |
           pip install hererocks


### PR DESCRIPTION
Updates the [`actions/checkout`](https://github.com/actions/checkout) action used in the GitHub Actions workflows to its newest major version.

Still using v3 of `actions/checkout` will generate some warning like in this run: https://github.com/FourierTransformer/lua-simdjson/actions/runs/10173326514

> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

The PR will get rid of those warnings for `actions/checkout`, because v4 uses Node.js 20.