### PR TITLE
[ci] Update luarocks on windows to avoid hack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Lua (${{ matrix.lua }})
         run: |
           pip install hererocks
-          hererocks lua_install -r^ --${{ matrix.lua }}
+          hererocks lua_install -r@3a142ce --${{ matrix.lua }}
       - name: Build lua-simdjson
         run: |
           .\lua_install\bin\activate
@@ -56,6 +56,6 @@ jobs:
       - name: Run tests
         run: |
           .\lua_install\bin\activate
-          luarocks install MSVCRT="m" lua-cjson2
-          luarocks install MSVCRT="m" busted
+          luarocks install lua-cjson2
+          luarocks install busted
           busted --verbose


### PR DESCRIPTION
The latest version of luarocks has added ucrt support (windows-2022 has ucrt mingw installed). This means we can avoid the MSVCRT="m" hack. See https://github.com/luarocks/luarocks/issues/1697.