### PR TITLE
[make] Recompile library when source files change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ test/
 *.so
 *.dll
 *.o
+*.d

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 test/
 *.so
 *.dll
+*.o

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ all: $(TARGET)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
 $(TARGET): $(OBJ)
-	$(CC) $(LDFLAGS) $^ -o $@ $(LDLIBS)
+	$(CXX) $(LDFLAGS) $^ -o $@ $(LDLIBS)
 
 clean:
 	rm -f *.$(LIBEXT) src/*.o

--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,17 @@ TARGET = simdjson.$(LIBEXT)
 
 all: $(TARGET)
 
-%.o: %.cpp %.h
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
+DEP_FILES = $(OBJ:.o=.d)
+-include $(DEP_FILES)
+
+%.o:
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -MMD -MP -c $< -o $@
 
 $(TARGET): $(OBJ)
 	$(CXX) $(LDFLAGS) $^ -o $@ $(LDLIBS)
 
 clean:
-	rm -f *.$(LIBEXT) src/*.o
+	rm -f *.$(LIBEXT) src/*.{o,d}
 
 install: $(TARGET)
 	cp $(TARGET) $(INST_LIBDIR)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ all: $(TARGET)
 DEP_FILES = $(OBJ:.o=.d)
 -include $(DEP_FILES)
 
-%.o:
+%.o: %.cpp
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -MMD -MP -c $< -o $@
 
 $(TARGET): $(OBJ)

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 OBJ = src/luasimdjson.o src/simdjson.o
-INCLUDE = -I$(LUA_INCDIR)
-FLAGS = -std=c++11 -Wall $(CFLAGS)
+CPPFLAGS = -I$(LUA_INCDIR)
+CXXFLAGS = -std=c++11 -Wall $(CFLAGS)
 LDFLAGS = $(LIBFLAG)
-LIBS = -lpthread
+LDLIBS = -lpthread
 
 ifdef LUA_LIBDIR
-LIBS += $(LUA_LIBDIR)/$(LUALIB)
+LDLIBS += $(LUA_LIBDIR)/$(LUALIB)
 endif
 
 ifeq ($(OS),Windows_NT)
@@ -26,10 +26,10 @@ TARGET = simdjson.$(LIBEXT)
 all: $(TARGET)
 
 %.o: %.cpp %.h
-	$(CXX) $(INCLUDE) $(FLAGS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
 $(TARGET): $(OBJ)
-	$(CC) $(LDFLAGS) $^ -o $@ $(LIBS)
+	$(CC) $(LDFLAGS) $^ -o $@ $(LDLIBS)
 
 clean:
 	rm -f *.$(LIBEXT) src/*.o

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-SRC = src/luasimdjson.cpp src/simdjson.cpp
+OBJ = src/luasimdjson.o src/simdjson.o
 INCLUDE = -I$(LUA_INCDIR)
+FLAGS = -std=c++11 -Wall $(CFLAGS)
+LDFLAGS = $(LIBFLAG)
 LIBS = -lpthread
-FLAGS = -std=c++11 -Wall $(LIBFLAG) $(CFLAGS)
 
 ifdef LUA_LIBDIR
-FLAGS += $(LUA_LIBDIR)/$(LUALIB)
+LIBS += $(LUA_LIBDIR)/$(LUALIB)
 endif
 
 ifeq ($(OS),Windows_NT)
@@ -24,11 +25,14 @@ TARGET = simdjson.$(LIBEXT)
 
 all: $(TARGET)
 
-$(TARGET):
-	$(CXX) $(SRC) $(FLAGS) $(INCLUDE) $(LIBS) -o $@
+%.o: %.cpp %.h
+	$(CXX) $(INCLUDE) $(FLAGS) -c $< -o $@
+
+$(TARGET): $(OBJ)
+	$(CC) $(LDFLAGS) $^ -o $@ $(LIBS)
 
 clean:
-	rm *.$(LIBEXT)
+	rm -f *.$(LIBEXT) src/*.o
 
 install: $(TARGET)
 	cp $(TARGET) $(INST_LIBDIR)


### PR DESCRIPTION
The build has been split up into separate object files, and each object file is recompiled if the relevant source/header file changes.

Previously, it would never recompile the library, regardless of whether any files had changed, so running `make clean` was necessary every time (which was inconvenient when I was doing a git bisect for #90).