### PR TITLE
Enable tests for invalid documents starting with n

### DIFF
--- a/jsonexamples/invalid/nully_trailing.json
+++ b/jsonexamples/invalid/nully_trailing.json
@@ -1,0 +1,1 @@
+nully trailing

--- a/spec/compile_spec.lua
+++ b/spec/compile_spec.lua
@@ -109,9 +109,9 @@ end
 local invalid_files = {
     "bool_trailing.json",
     "nil_token.json",
-    -- "nil_token_scalar.json",
+    "nil_token_scalar.json",
     "nully_token.json",
-    -- "nully_token_scalar.json"
+    "nully_token_scalar.json"
 }
 
 describe("Make sure invalid files are not accepted", function()

--- a/spec/compile_spec.lua
+++ b/spec/compile_spec.lua
@@ -108,6 +108,7 @@ end
 
 local invalid_files = {
     "bool_trailing.json",
+    "nully_trailing.json",
     "nil_token.json",
     "nil_token_scalar.json",
     "nully_token.json",

--- a/src/luasimdjson.cpp
+++ b/src/luasimdjson.cpp
@@ -124,6 +124,9 @@ void convert_ondemand_element_to_table(lua_State *L, T& element) {
       // calling is_null().value() will trigger an exception if the value is invalid
       if (element.is_null().value()) {
         lua_pushlightuserdata(L, NULL);
+      } else {
+        // workaround for simdjson 3.10.1
+        throw simdjson_error(INCORRECT_TYPE);
       }
       break;
   }


### PR DESCRIPTION
Disabled in #93 as these tests are broken due to a simdjson bug: https://github.com/simdjson/simdjson/pull/2258

For now, we can just manually throw the exception until the next simdjson bugfix release, at which point the workaround can be removed.