### PR TITLE
Add support for windows with MSVC toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
         run: |
           pip install hererocks
           hererocks lua_install -rhttps://github.com/tobil4sk/luarocks@46903c2 --${{ matrix.lua }} --target ${{ matrix.target }}
+
+          # Workaround for: https://github.com/luarocks/luarocks/issues/1726
+          .\lua_install\bin\activate
+          luarocks install compat53
       - name: Build lua-simdjson
         run: |
           .\lua_install\bin\activate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Lua (${{ matrix.lua }})
         run: |
           pip install hererocks
-          hererocks lua_install -r@3a142ce --${{ matrix.lua }} --target ${{ matrix.target }}
+          hererocks lua_install -rhttps://github.com/tobil4sk/luarocks@46903c2 --${{ matrix.lua }} --target ${{ matrix.target }}
       - name: Build lua-simdjson
         run: |
           .\lua_install\bin\activate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,7 @@ jobs:
       - name: Install Lua (${{ matrix.lua }})
         run: |
           pip install hererocks
-          # patched luarocks: https://github.com/luarocks/luarocks/pull/1757
-          hererocks lua_install -rhttps://github.com/tobil4sk/luarocks@vendor-lua-compat53 --${{ matrix.lua }} --target ${{ matrix.target }}
+          hererocks lua_install -r@28f9d98 --${{ matrix.lua }} --target ${{ matrix.target }}
       - name: Build lua-simdjson
         run: |
           .\lua_install\bin\activate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,8 @@ jobs:
       - name: Install Lua (${{ matrix.lua }})
         run: |
           pip install hererocks
-          hererocks lua_install -rhttps://github.com/tobil4sk/luarocks@46903c2 --${{ matrix.lua }} --target ${{ matrix.target }}
-
-          # Workaround for: https://github.com/luarocks/luarocks/issues/1726
-          .\lua_install\bin\activate
-          luarocks install compat53
+          # patched luarocks: https://github.com/luarocks/luarocks/pull/1757
+          hererocks lua_install -rhttps://github.com/tobil4sk/luarocks@vendor-lua-compat53 --${{ matrix.lua }} --target ${{ matrix.target }}
       - name: Build lua-simdjson
         run: |
           .\lua_install\bin\activate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         lua: [lua=5.1, lua=5.2, lua=5.3, lua=5.4, luajit=2.0, luajit=2.1]
+        target: [mingw,vs]
     runs-on: windows-2022
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE.
@@ -53,7 +54,7 @@ jobs:
       - name: Install Lua (${{ matrix.lua }})
         run: |
           pip install hererocks
-          hererocks lua_install -r@3a142ce --${{ matrix.lua }}
+          hererocks lua_install -r@3a142ce --${{ matrix.lua }} --target ${{ matrix.target }}
       - name: Build lua-simdjson
         run: |
           .\lua_install\bin\activate

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ test/
 *.dll
 *.o
 *.d
+
+# msvc
+*.obj
+*.lib
+*.exp

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,0 +1,27 @@
+OBJ = src/luasimdjson.obj src/simdjson.obj
+CPPFLAGS = -I$(LUA_INCDIR)
+CXXFLAGS = -EHsc -std:c++17 $(CFLAGS)
+LDFLAGS = $(LIBFLAG)
+
+!ifdef LUA_LIBDIR
+LDLIBS = $(LUA_LIBDIR)/$(LUALIB)
+!endif
+
+TARGET = simdjson.dll
+
+all: $(TARGET)
+
+src/luasimdjson.obj: src/luasimdjson.h src/simdjson.h
+src/simdjson.obj: src/simdjson.h
+
+.cpp.obj::
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -Fo:"src\\"
+
+$(TARGET): $(OBJ)
+	$(LD) $(LDFLAGS) $** -out:$@ $(LDLIBS)
+
+clean:
+	del *.dll src\*.obj *.lib *.exp 2>nul
+
+install: $(TARGET)
+	copy $(TARGET) $(INST_LIBDIR)

--- a/lua-simdjson-0.0.6-1.rockspec
+++ b/lua-simdjson-0.0.6-1.rockspec
@@ -36,6 +36,7 @@ build = {
          build_variables = {
             LUA_LIBDIR="$(LUA_LIBDIR)",
             LUALIB="$(LUALIB)",
+            LD="$(LD)",
          }
       }
    }

--- a/src/luasimdjson.h
+++ b/src/luasimdjson.h
@@ -1,4 +1,11 @@
 #include <lua.hpp>
+
+#ifdef _MSC_VER
+#define LUASIMDJSON_EXPORT __declspec(dllexport)
+#else
+#define LUASIMDJSON_EXPORT extern
+#endif
+
 extern "C" {
 	static int parse(lua_State*);
 	static int parse_file(lua_State*);
@@ -6,15 +13,14 @@ extern "C" {
 	static int ParsedObject_open(lua_State*);
 	static int ParsedObject_open_file(lua_State*);
 
-
 	static const struct luaL_Reg luasimdjson[] = {
 		{"parse", parse},
 		{"parseFile", parse_file},
 		{"activeImplementation", active_implementation},
 		{"open", ParsedObject_open},
 		{"openFile", ParsedObject_open_file},
-			
+
 		{NULL, NULL},
 	};
-	int luaopen_simdjson (lua_State*);
+	LUASIMDJSON_EXPORT int luaopen_simdjson(lua_State*);
 }


### PR DESCRIPTION
Currently, only mingw builds are supported via mingw-make. This PR adds support for MSVC using nmake, which luarocks uses by default on MSVC based installations.