### PR TITLE
Fix missing LD flag for msvc makefile

### DIFF
--- a/lua-simdjson-scm-1.rockspec
+++ b/lua-simdjson-scm-1.rockspec
@@ -35,6 +35,7 @@ build = {
          build_variables = {
             LUA_LIBDIR="$(LUA_LIBDIR)",
             LUALIB="$(LUALIB)",
+            LD="$(LD)",
          }
       }
    }


### PR DESCRIPTION
This is an issue in the merging of #97 and #98