### PR TITLE
[make] Enable -fvisibility=hidden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 OBJ = src/luasimdjson.o src/simdjson.o
 CPPFLAGS = -I$(LUA_INCDIR)
-CXXFLAGS = -std=c++11 -Wall $(CFLAGS)
+CXXFLAGS = -std=c++11 -Wall -fvisibility=hidden $(CFLAGS)
 LDFLAGS = $(LIBFLAG)
 LDLIBS = -lpthread
 

--- a/src/luasimdjson.h
+++ b/src/luasimdjson.h
@@ -3,7 +3,7 @@
 #ifdef _MSC_VER
 #define LUASIMDJSON_EXPORT __declspec(dllexport)
 #else
-#define LUASIMDJSON_EXPORT extern
+#define LUASIMDJSON_EXPORT __attribute__((visibility("default")))
 #endif
 
 extern "C" {


### PR DESCRIPTION
This prevents symbols being exported by default, potentially resulting in more optimal code with a reduced binary size.

This also matches msvc behaviour.

See #107.